### PR TITLE
Add basic tunnel test geometry and checkerboard texture

### DIFF
--- a/Source/Barycentrics.h
+++ b/Source/Barycentrics.h
@@ -33,12 +33,14 @@ private:
 	void render();
 
 	bool loadModel(const char* filename);
+	bool loadTunnelTestModel();
 
 	Camera m_camera;
 	Camera m_interpolatedCamera;
 
 	CameraManipulator* m_cameraMan;
 
+	GfxTechnique m_techniqueTextured;
 	GfxTechnique m_techniqueNonIndexed;
 	GfxTechnique m_techniqueGeometryShader;
 	GfxTechnique m_techniqueIndexed;
@@ -120,6 +122,7 @@ private:
 		Manual,
 		PassthroughGS,
 		NativeAMD,
+		Textured,
 	} m_mode = Mode::NonIndexed;
 
 	const char* toString(Mode m)
@@ -133,6 +136,7 @@ private:
 		case Mode::Manual: return "Manual";
 		case Mode::PassthroughGS: return "PassthroughGS";
 		case Mode::NativeAMD: return "NativeAMD";
+		case Mode::Textured: return "Textured";
 		}
 	}
 };

--- a/Source/BaseApplication.cpp
+++ b/Source/BaseApplication.cpp
@@ -1,4 +1,5 @@
 #include "BaseApplication.h"
+#include "DemoUtils.h"
 
 #include <Rush/GfxBitmapFont.h>
 #include <Rush/GfxPrimitiveBatch.h>
@@ -96,7 +97,7 @@ BaseApplication::BaseApplication()
 		desc.wrapU          = GfxTextureWrap::Wrap;
 		desc.wrapV          = GfxTextureWrap::Wrap;
 		desc.wrapW          = GfxTextureWrap::Wrap;
-		desc.anisotropy     = 4.0f;
+		desc.anisotropy     = 16.0f;
 		m_samplerStates.anisotropicWrap.takeover(Gfx_CreateSamplerState(desc));
 	}
 
@@ -106,6 +107,23 @@ BaseApplication::BaseApplication()
 		const u32 whiteTexturePixels[4] = { 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF };
 		GfxTextureDesc textureDescr = GfxTextureDesc::make2D(2, 2);
 		m_defaultWhiteTexture = Gfx_CreateTexture(textureDescr, whiteTexturePixels);
+	}
+
+	{
+		const u32 dimension = 256;
+		const u32 square = dimension / 2;
+
+		std::vector<u32> pixels(dimension * dimension, 0x00000000);
+		for (u32 y = 0; y < square; ++y)
+		{
+			for (u32 x = 0; x < square; ++x)
+			{
+				pixels[y * dimension + x] = 0xFFFFFFFF;
+				pixels[(y + square) * dimension + (x + square)] = 0xFFFFFFFF;
+			}
+		}
+
+		m_checkerboardTexture = generateMipsRGBA8(reinterpret_cast<u8*>(pixels.data()), dimension, dimension);
 	}
 }
 

--- a/Source/BaseApplication.h
+++ b/Source/BaseApplication.h
@@ -51,4 +51,5 @@ protected:
 	BitmapFontRenderer* m_font;
 
 	GfxTexture m_defaultWhiteTexture;
+	GfxTexture m_checkerboardTexture;
 };

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -16,6 +16,7 @@ set(shaders
 	Shaders/ModelPassthrough.frag
 	Shaders/ModelPassthrough.geom
 	Shaders/ModelPassthrough.vert
+	Shaders/ModelTextured.frag
 )
 
 set(src

--- a/Source/DemoUtils.h
+++ b/Source/DemoUtils.h
@@ -54,3 +54,4 @@ inline u64 hashFnv1a64(const void* message, size_t length, u64 state = 0xcbf29ce
 std::string directoryFromFilename(const std::string& filename);
 GfxShaderSource shaderFromFile(const char* filename, const char* shaderDirectory = Platform_GetExecutableDirectory());
 GfxTexture textureFromFile(const char* filename);
+GfxTexture generateMipsRGBA8(u8* pixels, int w, int h);

--- a/Source/Shaders/Common.glsl
+++ b/Source/Shaders/Common.glsl
@@ -64,3 +64,21 @@ vec3 intersectRayTri(vec3 rayOrigin, vec3 rayDirection, vec3 v0, vec3 v1, vec3 v
 
 	return vec3(1.0 - b1 - b2, b1, b2);
 }
+
+vec2 interpolateTexCoords(uint primId, vec3 barycentrics)
+{
+	uint index0 = g_indices[3*primId+0];
+	uint index1 = g_indices[3*primId+1];
+	uint index2 = g_indices[3*primId+2];
+
+	Vertex vertex0 = getVertex(index0);
+	Vertex vertex1 = getVertex(index1);
+	Vertex vertex2 = getVertex(index2);
+
+	vec2 texcoord = 
+		vertex0.texcoord * barycentrics.x +
+		vertex1.texcoord * barycentrics.y +
+		vertex2.texcoord * barycentrics.z;
+
+	return texcoord;
+}

--- a/Source/Shaders/Model.frag
+++ b/Source/Shaders/Model.frag
@@ -10,26 +10,12 @@ layout (location = 0) out vec4 fragColor0;
 
 void main()
 {
-	fragColor0.rgb = vec3(v_barycentrics.x, v_barycentrics.y, 1.0 - v_barycentrics.x - v_barycentrics.y);
-	fragColor0.a = 1.0;
+	vec3 barycentrics = vec3(v_barycentrics.x, v_barycentrics.y, 1.0 - v_barycentrics.x - v_barycentrics.y);
 
-	/*
-	uint index0 = g_indices[v_primId*3];
-	uint index1 = g_indices[v_primId*3+1];
-	uint index2 = g_indices[v_primId*3+2];
+	vec2 texcoords = interpolateTexCoords(v_primId, barycentrics);	
+	vec3 textured = texture(albedoSampler, texcoords).rgb;
 
-	Vertex vertex0 = getVertex(index0);
-	Vertex vertex1 = getVertex(index1);
-	Vertex vertex2 = getVertex(index2);
-
-	float b0 = v_barycentrics.x;
-	float b1 = v_barycentrics.y;
-	float b2 = 1.0 - b0 - b1;
-
-	vec2 texcoord = vertex0.texcoord * b0 + vertex1.texcoord * b1 + vertex2.texcoord * b2;
-	vec3 outBaseColor = g_baseColor.rgb * texture(albedoSampler, texcoord).rgb;
-	
-	fragColor0.rgb = mix(vec3(b0, b1, b2), outBaseColor.rgb, 0.5);
+	fragColor0.rgb = barycentrics;
+	//fragColor0.rgb = textured;
 	fragColor0.a = 1;
-	*/
 }

--- a/Source/Shaders/ModelBarycentrics.geom
+++ b/Source/Shaders/ModelBarycentrics.geom
@@ -12,19 +12,20 @@ layout (location = 2) out vec3 v_viewVector;
 
 void main()
 {
-	v_primId = gl_PrimitiveID;
-
 	gl_Position = gl_in[0].gl_Position;
+	v_primId = gl_PrimitiveIDIn;
 	v_viewVector = v_viewVectorIn[0];
 	v_barycentrics = vec2(1,0);
 	EmitVertex();
 
 	gl_Position = gl_in[1].gl_Position;
+	v_primId = gl_PrimitiveIDIn;
 	v_viewVector = v_viewVectorIn[1];
 	v_barycentrics = vec2(0,1);
 	EmitVertex();
 
 	gl_Position = gl_in[2].gl_Position;
+	v_primId = gl_PrimitiveIDIn;
 	v_viewVector = v_viewVectorIn[2];
 	v_barycentrics = vec2(0,0);
 	EmitVertex();

--- a/Source/Shaders/ModelManual.frag
+++ b/Source/Shaders/ModelManual.frag
@@ -20,7 +20,11 @@ void main()
 		v_worldPos,
 		(vec4(vertex1.position, 1) * g_matWorld).xyz,
 		(vec4(vertex2.position, 1) * g_matWorld).xyz);
+	
+	vec2 texcoords = interpolateTexCoords(gl_PrimitiveID, barycentrics);	
+	vec3 textured = texture(albedoSampler, texcoords).rgb;
 
 	fragColor0.rgb = barycentrics;
-	fragColor0.a = 1.0;
+	//fragColor0.rgb = textured;
+	fragColor0.a = 1;
 }

--- a/Source/Shaders/ModelTextured.frag
+++ b/Source/Shaders/ModelTextured.frag
@@ -1,0 +1,13 @@
+#version 450
+
+#include "Common.glsl"
+
+layout (location = 0) in vec2 v_tex0;
+layout (location = 2) in vec3 v_viewVector;
+
+layout (location = 0) out vec4 fragColor0;
+
+void main()
+{
+	fragColor0 = texture(albedoSampler, v_tex0);
+}


### PR DESCRIPTION
Serves as a good precision test for barycentrics when used with a checkerboard texture.

Texturing is disabled on most of the techniques by default for now.
Can add an orthogonal UI for toggling it on/off as desired or just edit the shaders.

Will need to plumb primitive IDs through some of the other techniques for comparison.